### PR TITLE
Base para internacionalização com nest-i18n

### DIFF
--- a/nest-cli.json
+++ b/nest-cli.json
@@ -3,6 +3,9 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
-    "deleteOutDir": true
+    "deleteOutDir": true,
+    "assets": [
+      { "include": "i18n/**/*", "watchAssets": true }
+    ]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
         "nest-aws-sdk": "^3.0.1",
+        "nestjs-i18n": "^10.4.5",
         "reflect-metadata": "^0.2.0",
         "rxjs": "^7.8.1"
       },
@@ -2631,6 +2632,12 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
+    "node_modules/accept-language-parser": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/accept-language-parser/-/accept-language-parser-1.5.0.tgz",
+      "integrity": "sha512-QhyTbMLYo0BBGg1aWbeMG4ekWtds/31BrEU+DONOg/7ax23vxpL03Pb7/zBmha2v7vdD3AyzZVWBVGEZxKOXWw==",
+      "license": "MIT"
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -2791,7 +2798,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -2804,7 +2810,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -2857,8 +2862,7 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
@@ -3116,7 +3120,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -3198,7 +3201,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "dependencies": {
         "fill-range": "^7.1.1"
       },
@@ -3402,7 +3404,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -4638,7 +4639,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -4886,7 +4886,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -5013,7 +5012,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -5374,7 +5372,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -5412,7 +5409,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5452,7 +5448,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -5473,7 +5468,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -6364,7 +6358,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -6920,6 +6913,38 @@
         "rxjs": ">= 6.5.4"
       }
     },
+    "node_modules/nestjs-i18n": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/nestjs-i18n/-/nestjs-i18n-10.4.5.tgz",
+      "integrity": "sha512-OamX+Bf7yGtbKnfMLQNaVZL89YmFfcYCf0Y+R282D3rExpXDvHNNVrSbJoOXPK2fBq7/lnhlVYwEHiniqOiqXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accept-language-parser": "^1.5.0",
+        "chokidar": "^3.5.3",
+        "cookie": "^0.5.0",
+        "iterare": "^1.2.1",
+        "js-yaml": "^4.1.0",
+        "string-format": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "*",
+        "@nestjs/core": "*",
+        "class-validator": "*",
+        "rxjs": "*"
+      }
+    },
+    "node_modules/nestjs-i18n/node_modules/cookie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/node-abort-controller": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
@@ -6989,7 +7014,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7615,7 +7639,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -7627,7 +7650,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -8175,6 +8197,12 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
+    "node_modules/string-format": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/string-format/-/string-format-2.0.0.tgz",
+      "integrity": "sha512-bbEs3scLeYNXLecRRuk6uJxdXUSj6le/8rNPHChIJTn2V79aXVTR1EH2OH5zLKKoz0V02fOUKZZcw01pLUShZA==",
+      "license": "WTFPL OR MIT"
+    },
     "node_modules/string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -8599,7 +8627,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
     "nest-aws-sdk": "^3.0.1",
+    "nestjs-i18n": "^10.4.5",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1"
   },

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -17,6 +17,8 @@ import { FarmController } from './controllers/farm.controller';
 import { FarmService } from './services/farm.service';
 import { EventService } from './services/event.service';
 import { EventController } from './controllers/event.controller';
+import { AcceptLanguageResolver, I18nModule, QueryResolver } from 'nestjs-i18n';
+import { join } from 'path';
 
 @Module({
   imports: [
@@ -31,6 +33,17 @@ import { EventController } from './controllers/event.controller';
         s3ForcePathStyle: true,
       },
       services: [S3],
+    }),
+    I18nModule.forRoot({
+      fallbackLanguage: 'pt',
+      loaderOptions: {
+        path: join(__dirname, '/i18n/'),
+        watch: true,
+      },
+      resolvers: [
+        { use: QueryResolver, options: ['lang'] },
+        AcceptLanguageResolver,
+      ],
     }),
   ],
   controllers: [

--- a/src/controllers/event.controller.ts
+++ b/src/controllers/event.controller.ts
@@ -5,6 +5,7 @@ import {
   Req,
 } from '@nestjs/common';
 import { Request } from 'express';
+import { I18n, I18nContext } from 'nestjs-i18n';
 import { EventService } from 'src/services/event.service';
 
 @Controller('event')
@@ -12,13 +13,13 @@ export class EventController {
   constructor(private eventService: EventService) {}
 
   @Get()
-  public async listEvents(@Req() request: Request) {
+  public async listEvents(@Req() request: Request, @I18n() i18n: I18nContext) {
     try {
       return await this.eventService.listEvents(+request['user'].sub);
     } catch (error) {
       console.log(error);
       throw new InternalServerErrorException(
-        'Algum erro inesperado aconteceu, tente novamente mais tarde',
+        i18n.t('responses.MESSAGES.INTERNAL_SERVER_ERROR')
       );
     }
   }

--- a/src/controllers/farm.controller.ts
+++ b/src/controllers/farm.controller.ts
@@ -13,6 +13,7 @@ import {
 } from '@nestjs/common';
 import { FilesInterceptor } from '@nestjs/platform-express';
 import { Request } from 'express';
+import { I18n, I18nContext } from 'nestjs-i18n';
 import { CreateFarmDto } from 'src/dto/farm.dto';
 import { FarmService } from 'src/services/farm.service';
 
@@ -24,6 +25,7 @@ export class FarmController {
   public async createFarm(
     @Body() farm: CreateFarmDto,
     @Req() request: Request,
+    @I18n() i18n: I18nContext
   ) {
     try {
       return this.farmService.createFarm({
@@ -47,32 +49,32 @@ export class FarmController {
       });
     } catch (error) {
       throw new InternalServerErrorException(
-        'Algum erro inesperado aconteceu, tente novamente mais tarde',
+        i18n.t('responses.MESSAGES.INTERNAL_SERVER_ERROR')
       );
     }
   }
 
   @Get()
-  public async listFarms() {
+  public async listFarms(@I18n() i18n: I18nContext) {
     try {
       return await this.farmService.listFarms();
     } catch (error) {
       throw new InternalServerErrorException(
-        'Algum erro inesperado aconteceu, tente novamente mais tarde',
+        i18n.t('responses.MESSAGES.INTERNAL_SERVER_ERROR')
       );
     }
   }
 
   @Get(':id')
-  public async getFarm(@Param('id') id: number) {
+  public async getFarm(@Param('id') id: number, @I18n() i18n: I18nContext) {
     try {
       return await this.farmService.getFarm(+id);
     } catch (error) {
       if (error.message === 'notFound') {
-        throw new NotFoundException('Chácara não encontrada');
+        throw new NotFoundException(i18n.t('responses.MESSAGES.FARM_NOT_FOUND'));
       }
       throw new InternalServerErrorException(
-        'Algum erro inesperado aconteceu, tente novamente mais tarde',
+        i18n.t('responses.MESSAGES.INTERNAL_SERVER_ERROR')
       );
     }
   }
@@ -82,13 +84,14 @@ export class FarmController {
   async submitProfilePicture(
     @UploadedFiles() files: Express.Multer.File[],
     @Query('farmId') farmId: string,
+    @I18n() i18n: I18nContext
   ) {
     try {
       return this.farmService.uploadFarmPics(files, +farmId);
     } catch (error) {
       console.log(error);
       throw new InternalServerErrorException(
-        'Algum erro inesperado aconteceu, tente novamente mais tarde',
+        i18n.t('responses.MESSAGES.INTERNAL_SERVER_ERROR')
       );
     }
   }

--- a/src/controllers/lessee.controller.ts
+++ b/src/controllers/lessee.controller.ts
@@ -8,6 +8,7 @@ import {
 import { LesseeService } from '../services/lessee.service';
 import { CreateLesseeDTO } from 'src/dto/lessee.dto';
 import { Public } from 'src/constants/ispublic';
+import { I18n, I18nContext } from 'nestjs-i18n';
 
 @Controller('lessee')
 export class LesseeController {
@@ -15,20 +16,20 @@ export class LesseeController {
 
   @Public()
   @Post()
-  async createLessee(@Body() lessee: CreateLesseeDTO) {
+  async createLessee(@Body() lessee: CreateLesseeDTO, @I18n() i18n: I18nContext) {
     try {
       const createdLessee = await this.lesseeService.createLessee(lessee);
 
       return {
-        message: 'Conta criada com sucesso',
+        message: i18n.t('responses.MESSAGES.CREATE_ACCOUNT_OK'),
         data: createdLessee,
       };
     } catch (error) {
       if (error.code === 'P2002') {
-        throw new BadRequestException('Endereço e-mail indisponível');
+        throw new BadRequestException(i18n.t('responses.MESSAGES.EMAIL_ADDRESS_UNAVAIABLE'));
       } else {
         throw new InternalServerErrorException(
-          'Algum erro inesperado aconteceu, tente novamente mais tarde',
+          i18n.t('responses.MESSAGES.INTERNAL_SERVER_ERROR')
         );
       }
     }

--- a/src/controllers/lessor.controller.ts
+++ b/src/controllers/lessor.controller.ts
@@ -8,6 +8,7 @@ import {
 import { LessorService } from '../services/lessor.service';
 import { CreateLessorDTO } from 'src/dto/lessor.dto';
 import { Public } from 'src/constants/ispublic';
+import { I18n, I18nContext } from 'nestjs-i18n';
 
 @Controller('lessor')
 export class LessorController {
@@ -15,7 +16,8 @@ export class LessorController {
 
   @Public()
   @Post()
-  async createLessor(@Body() lessor: CreateLessorDTO) {
+  async createLessor(@Body() lessor: CreateLessorDTO, @I18n() i18n: I18nContext) {
+    console.log(i18n.t('responses.TEST.LIBRARY'))
     try {
       const createdLessor = await this.lessorService.createLessor(lessor);
 

--- a/src/controllers/lessor.controller.ts
+++ b/src/controllers/lessor.controller.ts
@@ -17,20 +17,19 @@ export class LessorController {
   @Public()
   @Post()
   async createLessor(@Body() lessor: CreateLessorDTO, @I18n() i18n: I18nContext) {
-    console.log(i18n.t('responses.TEST.LIBRARY'))
     try {
       const createdLessor = await this.lessorService.createLessor(lessor);
 
       return {
-        message: 'Conta criada com sucesso',
+        message: i18n.t('responses.MESSAGES.CREATE_ACCOUNT_OK'),
         data: createdLessor,
       };
     } catch (error) {
       if (error.code === 'P2002') {
-        throw new BadRequestException('Endereço e-mail indisponível');
+        throw new BadRequestException(i18n.t('responses.MESSAGES.EMAIL_ADDRESS_UNAVAIABLE'));
       } else {
         throw new InternalServerErrorException(
-          'Algum erro inesperado aconteceu, tente novamente mais tarde',
+          i18n.t('responses.MESSAGES.INTERNAL_SERVER_ERROR')
         );
       }
     }

--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -13,6 +13,7 @@ import { Request } from 'express';
 import { Public } from 'src/constants/ispublic';
 import { AuthDTO } from 'src/dto/auth.dto';
 import { UserService } from 'src/services/user.service';
+import { I18n, I18nContext } from 'nestjs-i18n';
 
 @Controller('user')
 export class UserController {
@@ -20,20 +21,20 @@ export class UserController {
 
   @Public()
   @Post('auth')
-  async auth(@Body() login: AuthDTO) {
+  async auth(@Body() login: AuthDTO, @I18n() i18n: I18nContext) {
     try {
       const authResult = await this.userService.auth(login);
 
       return {
-        message: 'Conta criada com sucesso',
+        message: i18n.t('responses.MESSAGES.CREATE_ACCOUNT_OK'),
         data: authResult,
       };
     } catch (error) {
       if (error.code === 'P2025') {
-        throw new BadRequestException('Autenticação feita com sucesso');
+        throw new BadRequestException(i18n.t('responses.MESSAGES.AUTHENTICATION_OK'),);
       } else {
         throw new InternalServerErrorException(
-          'Algum erro inesperado aconteceu, tente novamente mais tarde',
+          i18n.t('responses.MESSAGES.INTERNAL_SERVER_ERROR')
         );
       }
     }

--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -45,6 +45,7 @@ export class UserController {
   async submitProfilePicture(
     @UploadedFile() file: Express.Multer.File,
     @Req() request: Request,
+    @I18n() i18n: I18nContext
   ) {
     try {
       return this.userService.uploadProfilePicture(
@@ -54,7 +55,7 @@ export class UserController {
     } catch (error) {
       console.log(error);
       throw new InternalServerErrorException(
-        'Algum erro inesperado aconteceu, tente novamente mais tarde',
+          i18n.t('responses.MESSAGES.INTERNAL_SERVER_ERROR')
       );
     }
   }

--- a/src/i18n/pt/responses.json
+++ b/src/i18n/pt/responses.json
@@ -1,5 +1,12 @@
 {
     "TEST": {
         "LIBRARY": "Testing use library nest-i18n"
+    },
+    "MESSAGES" : {
+        "CREATE_ACCOUNT_OK": "Conta criada com sucesso",
+        "AUTHENTICATION_OK": "Autenticação feita com sucesso",
+        "EMAIL_ADDRESS_UNAVAIABLE": "Endereço e-mail indisponível",
+        "INTERNAL_SERVER_ERROR": "Algum erro inesperado aconteceu, tente novamente mais tarde",
+        "FARM_NOT_FOUND": "Chácara não encontrada"
     }
 }

--- a/src/i18n/pt/responses.json
+++ b/src/i18n/pt/responses.json
@@ -1,0 +1,5 @@
+{
+    "TEST": {
+        "LIBRARY": "Testing use library nest-i18n"
+    }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,6 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.useGlobalPipes(new ValidationPipe());
   app.enableCors();
-  await app.listen(3001);
+  await app.listen(3000);
 }
 bootstrap();


### PR DESCRIPTION
## Cria o setup para a internacionalização do projeto, utilizando a biblioteca nest-i18n.

Strings de retorno serão armazenadas na pasta src/i18n/* de acordo com seus idiomas, como no exemplo abaixo:
```
package.json
package-lock.json
...
src
└── i18n
    ├── en
    │   ├── events.json
    │   └── test.json
    └── nl
        ├── events.json
        └── test.json
```
Insira o texto tokenizado no .json e então o chame dentro do controller conforme o exemplo abaixo:
```
{
  //src/i18n/responses.js
  "HELLO": "Hello"
}
```
```
import { Controller, Get } from '@nestjs/common';
import { I18n, I18nContext } from 'nestjs-i18n';

@Controller()
export class AppController {
  @Get()
  async getHello(@I18n() i18n: I18nContext) {
    return await i18n.t('test.HELLO');
  }
}
```